### PR TITLE
Change code examples to match downloaded filename.

### DIFF
--- a/exercises/taxiData.md
+++ b/exercises/taxiData.md
@@ -57,7 +57,7 @@ env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 
 // get the taxi ride data stream
 DataStream<TaxiRide> rides = env.addSource(
-  new TaxiRideSource("/path/to/nycTaxiTrip.gz", maxDelay, servingSpeed));
+  new TaxiRideSource("/path/to/nycTaxiRides.gz", maxDelay, servingSpeed));
 {% endhighlight %}
 
 #### Scala
@@ -70,5 +70,5 @@ env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
 
 // get the taxi ride data stream
 val rides = env.addSource(
-  new TaxiRideSource("/path/to/nycTaxiTrip.gz", maxDelay, servingSpeed))
+  new TaxiRideSource("/path/to/nycTaxiRides.gz", maxDelay, servingSpeed))
 {% endhighlight %}


### PR DESCRIPTION
The link to the gz file points to nycTaxiRides, but the code examples have nycTaxiTrip as the filename.
