### PR TITLE
Update _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,9 +1,9 @@
 # Site settings
 title: Apache Flink™ Training
 description: > # this means to ignore newlines until "baseurl:"
-  Write an awesome description for your new site here. You can edit this
-  line in _config.yml. It will appear in your document head meta (for
-  Google search results) and in your feed.xml site description.
+  Training material for Apache Flink™, including environment setup,
+  implementation of programs using the Flink APIs, and packaging,
+  execution and monitoring of Flink programs.
 baseurl: "/flink-training" # the subpath of your site, e.g. /blog/
 url: "http://dataartisans.github.io" # the base hostname & protocol for your site
 


### PR DESCRIPTION
Just noticed the default text when I sent the link to a co-worker, this should improve the discoverability of the training. Feel free to suggest alternative text.
