### PR TITLE
Fix urls in Advanced Streaming exercises

### DIFF
--- a/exercises/carSegments.md
+++ b/exercises/carSegments.md
@@ -4,7 +4,7 @@ title: Advanced DataStream API - Connected Car Segments
 permalink: /exercises/carSegments.html
 ---
 
-The objective of the Connected Car Segments exercise is to divide the [connected car data stream](/exercises/connectedCar.html)
+The objective of the Connected Car Segments exercise is to divide the [connected car data stream]({{ site.baseurl }}/exercises/connectedCar.html)
 into segmented windows, where segments are periods of continuous driving, punctuated by the car coming to a complete stop (the speed is 0.0).
 
 Your window function should look something like this, but we'll leave it to you to fill in the details:

--- a/exercises/carSessions.md
+++ b/exercises/carSessions.md
@@ -4,7 +4,7 @@ title: Advanced DataStream API - Connected Car Sessions
 permalink: /exercises/carSessions.html
 ---
 
-The objective of the Connected Car Sessions exercise is to divide the [connected car data stream](/exercises/connectedCar.html)
+The objective of the Connected Car Sessions exercise is to divide the [connected car data stream]({{ site.baseurl }}/exercises/connectedCar.html)
 into session windows, where a gap of more than 15 seconds should start a new session.
 
 Your window function should look something like this, but we'll leave it to you to fill in the details:

--- a/exercises/carSort.md
+++ b/exercises/carSort.md
@@ -5,7 +5,7 @@ permalink: /exercises/carSort.html
 ---
 
 The objective of this exercise is to sort the out-of-order version of
-the [connected car data stream](/exercises/connectedCar.html) by
+the [connected car data stream]({{ site.baseurl }}/exercises/connectedCar.html) by
 timestamp, keyed by the carId.
 
 The first few lines of output should look like this:


### PR DESCRIPTION
Previously links were unreachable, like first link here:

http://dataartisans.github.io/flink-training/exercises/carSessions.html